### PR TITLE
feat: add helper:pinGitHubActionDigests to extends array

### DIFF
--- a/default.json
+++ b/default.json
@@ -9,7 +9,8 @@
     ":semanticCommitScope(deps)",
     "docker:enableMajor",
     "docker:pinDigests",
-    "group:linters"
+    "group:linters",
+    "helper:pinGitHubActionDigests"
   ],
   "assignees": ["rarkins", "viceice"],
   "automergeType": "branch",


### PR DESCRIPTION
## Changes:

- Add `"helper:pinGitHubActionDigests"` to `extends` array

## Context:

This should make it so we pin our GitHub Actions to a full length Git commit hash.