### PR TITLE
add helpers:pinGitHubActionDigests to extends array

### DIFF
--- a/default.json
+++ b/default.json
@@ -9,7 +9,8 @@
     ":semanticCommitScope(deps)",
     "docker:enableMajor",
     "docker:pinDigests",
-    "group:linters"
+    "group:linters",
+    "helpers:pinGitHubActionDigests"
   ],
   "assignees": ["rarkins", "viceice"],
   "automergeType": "branch",


### PR DESCRIPTION
## Changes:

- Use the proper configuration option to pin our GitHub Actions...

## Context:

This is a re-try of bad PR #2.

Probably should wait with merging this until @viceice's fix is live on the hosted app.
https://github.com/renovatebot/renovate/pull/10858