### PR TITLE
feat: enable `yarnDedupeHighest`

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,6 +16,7 @@
   "dependencyDashboard": true,
   "prCreation": "not-pending",
   "separateMajorMinor": true,
+  "postUpdateOptions": ["yarnDedupeHighest"],
   "packageRules": [
     {
       "description": "Require dashboard approval for major updates except Renovate",


### PR DESCRIPTION
otherwise we get a lot duplicates until next lockfile maintenance. Those duplicates already caused errors on renovate repo